### PR TITLE
Migrate biome.json recommended field to preset

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "noParameterAssign": "error",
         "useAsConstAssertion": "error",


### PR DESCRIPTION
## Summary
- `linter.rules.recommended` was deprecated in Biome 2.5.7, causing `biome check` to emit a deprecation info message
- Switched to `linter.rules.preset: "recommended"` to clear the warning (the effective rule set is unchanged)

## Test plan
- [x] Ran `npm run lint` and confirmed no deprecation info is emitted
- [x] Confirmed `git diff biome.json` shows only a 1-line change

🤖 Generated with [Claude Code](https://claude.com/claude-code)